### PR TITLE
Fix link creation on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,8 +140,8 @@ The simplest way to build it:
     mkdir build && cd build
     cmake -DCMAKE_BUILD_TYPE=Release ..
     make
-    if [ -d ~/.local/bin ]; then ln -s ryzenadj ~/.local/bin/ryzenadj && echo "symlinked to ~/.local/bin/ryzenadj"; fi
-    if [ -d ~/.bin ]; then ln -s ryzenadj ~/.bin/ryzenadj && echo "symlinked to ~/.bin/ryzenadj"; fi
+    if [ -d ~/.local/bin ]; then ln -s $(readlink -f ryzenadj) ~/.local/bin/ryzenadj && echo "symlinked to ~/.local/bin/ryzenadj"; fi
+    if [ -d ~/.bin ]; then ln -s $(readlink -f ryzenadj) ~/.bin/ryzenadj && echo "symlinked to ~/.bin/ryzenadj"; fi
 
 ### Windows
 


### PR DESCRIPTION
Without `readlink -f` the results is a broken link because it won't point to the full path, just relative to the `bin` folder itself.

Like this: 

```
ryzenadj -> ryzenadj
```